### PR TITLE
analytics: add a Flush() method to wait on analytics reports

### DIFF
--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,39 @@
+package analytics_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/windmilleng/wmclient/pkg/analytics"
+)
+
+func TestFlush(t *testing.T) {
+	f := newAnalyticsFixture(t)
+	for i := 0; i < 10; i++ {
+		f.a.Incr("event", nil)
+	}
+
+	f.a.Flush(time.Second)
+	if len(f.reqs) != 10 {
+		t.Errorf("Expected 10 events sent. Actual: %d", len(f.reqs))
+	}
+}
+
+type analyticsFixture struct {
+	t    *testing.T
+	a    analytics.Analytics
+	reqs []*http.Request
+}
+
+func newAnalyticsFixture(t *testing.T) *analyticsFixture {
+	f := &analyticsFixture{t: t}
+	a := analytics.NewRemoteAnalytics(f, "test-app", "/report", "random-user", true)
+	f.a = a
+	return f
+}
+
+func (f *analyticsFixture) Do(req *http.Request) (*http.Response, error) {
+	f.reqs = append(f.reqs, req)
+	return &http.Response{StatusCode: 200}, nil
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/flush:

c43bdb5e9155f1efbe96ea8df8df399282ebce5d (2018-08-03 16:24:18 -0400)
analytics: add a Flush() method to wait on analytics reports