### PR TITLE
analytics: print the user id as part of the status command

### DIFF
--- a/pkg/analytics/cli.go
+++ b/pkg/analytics/cli.go
@@ -16,7 +16,8 @@ func analyticsStatus(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("analytics status: %s\n", choice)
+	fmt.Printf("analytics status : %s\n", choice)
+	fmt.Printf("analytics user id: %s\n", getUserID())
 
 	return nil
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/user:

3b5c9089eac1fdfe04ffdb86802875a80d7b799f (2018-10-03 14:11:57 -0400)
analytics: print the user id as part of the status command