### PR TITLE
analytics: add global tags to remote analytics

### DIFF
--- a/pkg/analytics/option.go
+++ b/pkg/analytics/option.go
@@ -1,0 +1,11 @@
+package analytics
+
+type Option func(a *remoteAnalytics)
+
+func WithGlobalTags(tags map[string]string) Option {
+	return Option(func(a *remoteAnalytics) {
+		for k, v := range tags {
+			a.globalTags[k] = v
+		}
+	})
+}


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/global:

1ad077fad7fb582d012494801ff2a997bfa75139 (2019-01-14 12:09:24 -0500)
analytics: add global tags to remote analytics