### PR TITLE
analytics: flesh out the options api, and make logging to stderr an option

### DIFF
--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -54,9 +54,19 @@ type analyticsFixture struct {
 	reqs []*http.Request
 }
 
-func newAnalyticsFixture(t *testing.T, options ...Option) *analyticsFixture {
+func newAnalyticsFixture(t *testing.T, fOptions ...Option) *analyticsFixture {
 	f := &analyticsFixture{t: t}
-	a := NewRemoteAnalytics(f, "test-app", "/report", "random-user", true, options...)
+	options := []Option{
+		WithHTTPClient(f),
+		WithReportURL("/report"),
+		WithUserID("random-user"),
+		WithEnabled(true),
+	}
+	options = append(options, fOptions...)
+	a, err := NewRemoteAnalytics("test-app", options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	f.a = a
 	return f
 }

--- a/pkg/analytics/opt.go
+++ b/pkg/analytics/opt.go
@@ -93,11 +93,11 @@ func readChoiceFile() (string, error) {
 	return strings.TrimSpace(txt), nil
 }
 
-func optedIn() bool {
+func optedIn() (bool, error) {
 	opt, err := OptStatus()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "analytics.optedIn: %v\n", err)
+		return false, fmt.Errorf("analytics.optedIn: %v", err)
 	}
 
-	return opt == OptIn
+	return opt == OptIn, nil
 }

--- a/pkg/analytics/option.go
+++ b/pkg/analytics/option.go
@@ -2,10 +2,47 @@ package analytics
 
 type Option func(a *remoteAnalytics)
 
+// Sets global tags for every report.
 func WithGlobalTags(tags map[string]string) Option {
 	return Option(func(a *remoteAnalytics) {
 		for k, v := range tags {
 			a.globalTags[k] = v
 		}
+	})
+}
+
+// Sets the URL to report to. Defaults to https://events.windmill.build/report
+func WithReportURL(url string) Option {
+	return Option(func(a *remoteAnalytics) {
+		a.url = url
+	})
+}
+
+// Sets the HTTP client. Defaults to golang http client.
+func WithHTTPClient(client HTTPClient) Option {
+	return Option(func(a *remoteAnalytics) {
+		a.cli = client
+	})
+}
+
+// Sets the UserID. Defaults to a user ID based on a hash of a machine identifier.
+func WithUserID(userID string) Option {
+	return Option(func(a *remoteAnalytics) {
+		a.userID = userID
+	})
+}
+
+// Sets whether the analytics client is enabled. Defaults to checking
+// the users' opt-in setting in ~/.windmill
+func WithEnabled(enabled bool) Option {
+	return Option(func(a *remoteAnalytics) {
+		a.enabled = enabled
+	})
+}
+
+// Sets the logger where errors are printed. Defaults to printing to stderr.
+func WithLogger(logger Logger) Option {
+	return Option(func(a *remoteAnalytics) {
+		a.logger = logger
 	})
 }


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/log:

0f917f86f33b5186fc64eef8a527f5299940c83e (2019-01-28 13:52:14 -0500)
analytics: flesh out the options api, and make logging to stderr an option

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics