### PR TITLE
analytics: use logger prefixing

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -38,7 +38,7 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
-var stdLogger = log.New(os.Stderr, "", log.LstdFlags)
+var stdLogger = log.New(os.Stderr, "[analytics] ", log.LstdFlags)
 
 func Init(appName string, options ...Option) (Analytics, *cobra.Command, error) {
 	a, err := NewRemoteAnalytics(appName, options...)
@@ -164,17 +164,17 @@ func (a *remoteAnalytics) count(name string, tags map[string]string, n int) {
 	req, err := a.countReq(name, tags, n)
 	if err != nil {
 		// Stat reporter can't return errs, just print it.
-		a.logger.Printf("[analytics] %v\n", err)
+		a.logger.Printf("Error: %v\n", err)
 		return
 	}
 
 	resp, err := a.cli.Do(req)
 	if err != nil {
-		a.logger.Printf("[analytics] http.Post: %v\n", err)
+		a.logger.Printf("http.Post: %v\n", err)
 		return
 	}
 	if resp.StatusCode != 200 {
-		a.logger.Printf("[analytics] http.Post returned status: %s\n", resp.Status)
+		a.logger.Printf("http.Post returned status: %s\n", resp.Status)
 	}
 }
 
@@ -205,17 +205,17 @@ func (a *remoteAnalytics) timer(name string, dur time.Duration, tags map[string]
 	req, err := a.timerReq(name, dur, tags)
 	if err != nil {
 		// Stat reporter can't return errs, just print it.
-		a.logger.Printf("[analytics] %v\n", err)
+		a.logger.Printf("Error: %v\n", err)
 		return
 	}
 
 	resp, err := a.cli.Do(req)
 	if err != nil {
-		a.logger.Printf("[analytics] http.Post: %v\n", err)
+		a.logger.Printf("http.Post: %v\n", err)
 		return
 	}
 	if resp.StatusCode != 200 {
-		a.logger.Printf("[analytics] http.Post returned status: %s\n", resp.Status)
+		a.logger.Printf("http.Post returned status: %s\n", resp.Status)
 	}
 
 }

--- a/pkg/analytics/option.go
+++ b/pkg/analytics/option.go
@@ -40,7 +40,8 @@ func WithEnabled(enabled bool) Option {
 	})
 }
 
-// Sets the logger where errors are printed. Defaults to printing to stderr.
+// Sets the logger where errors are printed.
+// Defaults to printing to stderr with the prefix "[analytics] ".
 func WithLogger(logger Logger) Option {
 	return Option(func(a *remoteAnalytics) {
 		a.logger = logger


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/log:

edf1e8b4d048d299c148d283aebd182d52b864ac (2019-01-28 18:30:20 -0500)
analytics: use logger prefixing

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics