### PR TITLE
analytics: use the default logger, so that log.SetOutput works by default. i can't believe i didn't think of this before

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -38,7 +37,11 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
-var stdLogger = log.New(os.Stderr, "[analytics] ", log.LstdFlags)
+type stdLogger struct{}
+
+func (stdLogger) Printf(format string, v ...interface{}) {
+	log.Printf("[analytics] %s", fmt.Sprintf(format, v...))
+}
 
 func Init(appName string, options ...Option) (Analytics, *cobra.Command, error) {
 	a, err := NewRemoteAnalytics(appName, options...)
@@ -108,7 +111,7 @@ func NewRemoteAnalytics(appName string, options ...Option) (*remoteAnalytics, er
 		url:        statsEndpt,
 		userID:     getUserID(),
 		enabled:    enabled,
-		logger:     stdLogger,
+		logger:     stdLogger{},
 		wg:         &sync.WaitGroup{},
 		globalTags: make(map[string]string),
 	}

--- a/pkg/analytics/option.go
+++ b/pkg/analytics/option.go
@@ -41,7 +41,7 @@ func WithEnabled(enabled bool) Option {
 }
 
 // Sets the logger where errors are printed.
-// Defaults to printing to stderr with the prefix "[analytics] ".
+// Defaults to printing to the default logger with the prefix "[analytics] ".
 func WithLogger(logger Logger) Option {
 	return Option(func(a *remoteAnalytics) {
 		a.logger = logger


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/log2:

fa400068744cde0564afb154e7bdd63b7f3fabae (2019-01-29 11:21:44 -0500)
analytics: use the default logger, so that log.SetOutput works by default. i can't believe i didn't think of this before

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics