### PR TITLE
analytics: SetOptStr returns the Opt enum it set

### DIFF
--- a/pkg/analytics/cli.go
+++ b/pkg/analytics/cli.go
@@ -34,7 +34,7 @@ func analyticsOpt(_ *cobra.Command, args []string) (outerErr error) {
 		return fmt.Errorf("no choice given; pass it as first arg: <tool> analytics opt <choice>")
 	}
 	choiceStr := args[0]
-	err := SetOptStr(choiceStr)
+	_, err := SetOptStr(choiceStr)
 	if err != nil {
 		return err
 	}

--- a/pkg/analytics/opt.go
+++ b/pkg/analytics/opt.go
@@ -46,7 +46,9 @@ func OptStatus() (Opt, error) {
 	return OptDefault, nil
 }
 
-func SetOptStr(s string) error {
+// SetOptStr converts the given string into an Opt enum, and records that choice
+// as the users analytics decision, returning the Opt set (and any errors).
+func SetOptStr(s string) (Opt, error) {
 	choice := OptDefault
 	for k, v := range Choices {
 		if v == s {
@@ -58,7 +60,7 @@ func SetOptStr(s string) error {
 		}
 	}
 
-	return SetOpt(choice)
+	return choice, SetOpt(choice)
 }
 
 func SetOpt(c Opt) error {


### PR DESCRIPTION
This will allow me to send back the Opt enum (rather than the opt string)
to the engine when we record a new opt (without having to duplicate the work
of translating string -> opt)