### PR TITLE
analytics: add a method for accessing the tags, so we can print them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.13

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFlush(t *testing.T) {
@@ -47,6 +49,10 @@ func TestGlobalTags(t *testing.T) {
 	if string(body) != expected {
 		t.Errorf("Request body did not match\nExpected: %s\nActual: %s", expected, string(body))
 	}
+
+	tag, ok := f.a.GlobalTag("fruit")
+	assert.True(t, ok)
+	assert.Equal(t, "pomelo", tag)
 }
 
 func TestIncrAnonymous(t *testing.T) {

--- a/pkg/analytics/option.go
+++ b/pkg/analytics/option.go
@@ -28,13 +28,13 @@ func WithHTTPClient(client HTTPClient) Option {
 // Sets the UserID. Defaults to a user ID based on a hash of a machine identifier.
 func WithUserID(userID string) Option {
 	return Option(func(a *remoteAnalytics) {
-		a.globalTags[keyUser] = userID
+		a.globalTags[TagUser] = userID
 	})
 }
 
 func WithMachineID(machineID string) Option {
 	return Option(func(a *remoteAnalytics) {
-		a.globalTags[keyMachine] = machineID
+		a.globalTags[TagMachine] = machineID
 	})
 }
 


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/tags:

74e3ccd4578f57d5999a76ccd466e62d02dd89d8 (2019-10-28 19:59:52 -0400)
analytics: add a method for accessing the tags, so we can print them