### PR TITLE
analytics: remove Init(). Analytics no longer relies on global state

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/denisbrodbeck/machineid"
-	"github.com/spf13/cobra"
 )
 
 const statsEndpt = "https://events.windmill.build/report"
@@ -43,20 +42,6 @@ type stdLogger struct{}
 
 func (stdLogger) Printf(format string, v ...interface{}) {
 	log.Printf("[analytics] %s", fmt.Sprintf(format, v...))
-}
-
-func Init(appName string, options ...Option) (Analytics, *cobra.Command, error) {
-	a, err := NewRemoteAnalytics(appName, options...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	c, err := initCLI()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return a, c, nil
 }
 
 type Analytics interface {

--- a/pkg/analytics/cli.go
+++ b/pkg/analytics/cli.go
@@ -48,7 +48,7 @@ func analyticsOpt(_ *cobra.Command, args []string) (outerErr error) {
 
 const choiceFile = "analytics/user/choice.txt"
 
-func initCLI() (*cobra.Command, error) {
+func NewCommand() *cobra.Command {
 	analytics := &cobra.Command{
 		Use:   "analytics",
 		Short: "info and status about windmill analytics",
@@ -61,6 +61,5 @@ func initCLI() (*cobra.Command, error) {
 		RunE:  analyticsOpt,
 	}
 	analytics.AddCommand(opt)
-
-	return analytics, nil
+	return analytics
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/logger:

5760d23570724b3014ca2a5f69a9ecb23422af0c (2020-01-23 20:39:57 -0500)
analytics: remove Init(). Analytics no longer relies on global state

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics