### PR TITLE
analytics: replace IncrAnonymous with WithoutGlobalTags(), which is more flexible and better expresses what it does

### DIFF
--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -55,9 +55,9 @@ func TestGlobalTags(t *testing.T) {
 	assert.Equal(t, "pomelo", tag)
 }
 
-func TestIncrAnonymous(t *testing.T) {
+func TestIncrWithoutGlobalTags(t *testing.T) {
 	f := newAnalyticsFixture(t, WithGlobalTags(map[string]string{"fruit": "pomelo"}))
-	f.a.IncrAnonymous("event", map[string]string{"season": "summer"})
+	f.a.WithoutGlobalTags().Incr("event", map[string]string{"season": "summer"})
 	f.a.Flush(time.Second)
 
 	if len(f.reqs) != 1 {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/analytics:

6d3ada81f988fba44f4112591c7a319e1e0958f4 (2020-02-05 13:05:13 -0500)
analytics: replace IncrAnonymous with WithoutGlobalTags(), which is more flexible and better expresses what it does

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics